### PR TITLE
Emit 'end' after error

### DIFF
--- a/gulp-prettyerror.js
+++ b/gulp-prettyerror.js
@@ -33,6 +33,9 @@ var PrettyError = (function(customErrorFormat){
                 _gutil.log('|\n    ' + msg + '\n           |');
                 _gutil.log('|- ' + _gutil.colors.bgRed('<<<'));
             }
+            
+            // make sure the process is finished
+            this.emit('end');
         });
     }
 });


### PR DESCRIPTION
This is to make sure the process is finished. I run gulp-less and the watcher is stuck if there is no emit end.